### PR TITLE
corrige le lien jquery

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -15,7 +15,7 @@
     <link rel="icon" type="image/png" href="{{ site.baseurl }}/images/logo_91x91.png" />
     <link rel="alternate" type="application/rss+xml" title="{{ site.name }}" href="{{ site.url }}/feed.xml" />
     <link rel="stylesheet" href="{{ site.baseurl }}/css/main.css">
-    <script src="http://code.jquery.com/jquery-1.10.1.min.js"></script>
+    <script src="//code.jquery.com/jquery-1.10.1.min.js"></script>
     <script src="{{ site.baseurl }}/js/main.js"></script>
     {% seo %}
 </head>


### PR DESCRIPTION
Sur mobile il n'est pas possible d'accéder au menu : le site est en https, la lib jquery ne l'est pas, par sécurité le navigateur désactive le chargement de la lib.
cf : https://developer.mozilla.org/en-US/docs/Learn/Common_questions/What_is_a_URL#Examples_of_absolute_URLs